### PR TITLE
chore: fix readme extension

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,0 @@
-# Fission
-
-Fission is a Luau decompiler.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Fission
+
+Fission is a Luau decompiler.


### PR DESCRIPTION
I noticed that the readme file had its extension fully capitalized. Therefore, I've changed it to be in lowercase such that the new file name is `README.md`.